### PR TITLE
combine caches into useful database

### DIFF
--- a/conda_index/index/convert_cache.py
+++ b/conda_index/index/convert_cache.py
@@ -301,7 +301,7 @@ def merge_index_cache(channel_root, output_db="merged.db"):
         if not os.path.exists(cache_db):
             continue
         channel_prefix = f"{channel_name}/{subdir}/"
-        print(f"{cache_db}")
+        print(f"merge {os.path.relpath(cache_db, os.path.dirname(channel_root))} as {channel_prefix}")
         combined_db.execute("ATTACH DATABASE ? AS subdir", (cache_db,))
 
         for table in TABLE_NAMES:
@@ -322,7 +322,7 @@ def merge_index_cache(channel_root, output_db="merged.db"):
                 print(e)
                 print(query)
 
-            combined_db.execute("DETACH DATABASE subdir")
+        combined_db.execute("DETACH DATABASE subdir")
 
 
 def test_from_archive(archive_path):

--- a/conda_index/index/convert_cache.py
+++ b/conda_index/index/convert_cache.py
@@ -284,6 +284,47 @@ def convert_cache(conn, cache_generator, override_channel=None):
                     log.warn("Unhandled", match.groupdict())
 
 
+def merge_index_cache(channel_root, output_db="merged.db"):
+    """
+    Combine {channel_root}/*/.cache/cache.db databases into a single database.
+    Useful for queries. Not used by any part of the indexing process.
+    """
+    from conda_index.utils import DEFAULT_SUBDIRS
+
+    channel_name = os.path.basename(channel_root)
+    print(f"merge caches for channel {channel_name}")
+    combined_db = common.connect(output_db)
+    with combined_db:
+        create(combined_db)  # skip 'remove prefix' migration
+    for subdir in DEFAULT_SUBDIRS:
+        cache_db = os.path.join(channel_root, subdir, ".cache", "cache.db")
+        if not os.path.exists(cache_db):
+            continue
+        channel_prefix = f"{channel_name}/{subdir}/"
+        print(f"{cache_db}")
+        combined_db.execute("ATTACH DATABASE ? AS subdir", (cache_db,))
+
+        for table in TABLE_NAMES:
+            # does sqlite do less work explicity avoiding "replace when row
+            # would not have changed"
+            column = {"icon": "icon_png"}.get(table, table)
+            if table == "icon":  # very rare
+                continue
+            query = f"""INSERT INTO main.{table} (path, {column})
+            SELECT ? || path, {column} FROM subdir.{table} WHERE true -- avoid syntax ambiguity
+            ON CONFLICT (path) DO UPDATE SET {column} = excluded.{column}
+            WHERE {column} != excluded.{column} -- does this avoid work
+            """
+            try:
+                with combined_db:
+                    combined_db.execute(query, (channel_prefix,))
+            except sqlite3.OperationalError as e:
+                print(e)
+                print(query)
+
+            combined_db.execute("DETACH DATABASE subdir")
+
+
 def test_from_archive(archive_path):
     conn = common.connect("linux-64-cache.db")
     create(conn)


### PR DESCRIPTION
Adds a prefix to filenames so you can store as many channels, subdirs in a single database. Useful for reporting.