### PR TITLE
shorten transactions; increase parallelism; separate output dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,8 @@ python -m conda_index.index --verbose --no-progress --threads=1 <path to channel
 * Mercilessly cull less-used features.
 
 * Format with `black`
+
+## Parallelism
+
+This version of conda-index continues indexing packages from other subdirs while
+the main thread is writing a repodata.json.

--- a/conda_index/api.py
+++ b/conda_index/api.py
@@ -7,6 +7,7 @@
 
 def update_index(
     dir_paths,
+    output_dir=None,
     check_md5=False,
     channel_name=None,
     subdir=None,
@@ -25,6 +26,10 @@ def update_index(
 
     dir_paths = [os.path.abspath(path) for path in ensure_list(dir_paths)]
 
+    assert (
+        output_dir is None or len(dir_paths) == 1
+    ), "Cannot combine output_dir with multiple paths"
+
     if isinstance(current_index_versions, str):
         with open(current_index_versions) as f:
             current_index_versions = yaml.safe_load(f)
@@ -32,6 +37,7 @@ def update_index(
     for path in dir_paths:
         update_index(
             path,
+            output_dir=output_dir,
             check_md5=check_md5,
             channel_name=channel_name,
             patch_generator=patch_generator,

--- a/conda_index/cli/main_index.py
+++ b/conda_index/cli/main_index.py
@@ -19,6 +19,10 @@ def parse_args(args):
         default=[os.getcwd()],
     )
     p.add_argument(
+        "--output",
+        help="Directory to generate index. Default [dir]. Cannot be used with multiple [dir].",
+    )
+    p.add_argument(
         "-c",
         "--check-md5",
         action="store_true",
@@ -80,8 +84,13 @@ def parse_args(args):
 def execute(args):
     _, args = parse_args(args)
 
+    if len(args.dir) != 1 and args.output:
+        print("Must specify exactly one input dir when using --output", file=sys.stderr)
+        sys.exit(1)
+
     api.update_index(
         args.dir,
+        output_dir=args.output,
         check_md5=args.check_md5,
         channel_name=args.channel_name,
         threads=args.threads,

--- a/conda_index/index/__init__.py
+++ b/conda_index/index/__init__.py
@@ -771,7 +771,7 @@ class ChannelIndex:
         # output repodata
         self.save_fs_state(cache, subdir_path)
 
-        log.debug("extraction")
+        log.debug("find packages to extract")
 
         # list so tqdm can show progress
         extract = [
@@ -783,16 +783,16 @@ class ChannelIndex:
             for row in self.changed_packages(cache)
         ]
 
+        log.debug("extract %d packages", len(extract))
+
         # now updates own stat cache
         extract_func = functools.partial(
             cache.extract_to_cache_2, self.channel_root, subdir
         )
 
         for fn, mtime, _size, index_json in tqdm(
-            self.thread_executor.map(
-                extract_func,
-                extract,
-            ),
+            # multiprocessing likes to hang
+            self.thread_executor.map(extract_func, extract),  # XXX individual timeouts?
             desc="hash & extract packages for %s" % subdir,
             disable=(verbose or not progress),
             leave=False,

--- a/conda_index/index/__init__.py
+++ b/conda_index/index/__init__.py
@@ -791,7 +791,7 @@ class ChannelIndex:
             WHERE stat.stage = ?
             ORDER BY path
         """,
-            ("fs",),
+            (cache.upstream_stage,),
         ):
             path, index_json = row
             # (convert path to base filename)

--- a/conda_index/index/convert_cache.py
+++ b/conda_index/index/convert_cache.py
@@ -147,6 +147,8 @@ def remove_prefix(conn: sqlite3.Connection):
     Call inside a transaction.
     """
 
+    log.info("Migrate database")
+
     def basename(path):
         if not isinstance(path, str):
             return path

--- a/conda_index/index/sqlitecache.py
+++ b/conda_index/index/sqlitecache.py
@@ -67,6 +67,8 @@ COMPUTED = {"info/post_install.json"}
 
 
 class CondaIndexCache:
+    upstream_stage = "fs"
+
     def __init__(self, channel_root, channel, subdir):
         """
         channel_root: directory containing platform subdir's, e.g. /clones/conda-forge
@@ -376,8 +378,8 @@ class CondaIndexCache:
         try:
             # recent stat information must exist here...
             stat = self.db.execute(
-                "SELECT mtime FROM stat WHERE stage='fs' AND path=:path",
-                {"path": self.database_path(fn)},
+                "SELECT mtime FROM stat WHERE stage=:upstream_stage AND path=:path",
+                {"upstream_stage": self.upstream_stage, "path": self.database_path(fn)},
             ).fetchone()
             mtime = stat["mtime"]
         except (KeyError, IndexError):

--- a/conda_index/index/sqlitecache.py
+++ b/conda_index/index/sqlitecache.py
@@ -473,7 +473,6 @@ class CondaIndexCache:
             if row[column]:  # is not null or empty
                 data.update(json.loads(row[column]))
 
-        # have to stat again, because we don't have access to the stat cache here
         data["mtime"] = mtime
 
         source = data.get("source", {})

--- a/conda_index/index/sqlitecache.py
+++ b/conda_index/index/sqlitecache.py
@@ -497,7 +497,7 @@ class CondaIndexCache:
         path_like = self.database_path_like
 
         # gather conda package filenames in subdir
-        log.debug("listdir")
+        log.debug("%s listdir", self.subdir)
         fns_in_subdir = {
             fn for fn in os.listdir(subdir_path) if fn.endswith((".conda", ".tar.bz2"))
         }
@@ -514,7 +514,7 @@ class CondaIndexCache:
                     "size": stat.st_size,
                 }
 
-        log.debug("save fs state")
+        log.debug("%s save fs state", self.subdir)
         with self.db:
             self.db.execute(
                 "DELETE FROM stat WHERE stage='fs' AND path like :path_like",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dynamic = ["version", "description"]
 requires-python = ">=3.9"
 dependencies = [
     "conda >=4.12.0",
-    "conda-build >=3.21.8",
+    "conda-build >=3.21.0",
     "conda-package-handling >=1.7.3",
     "filelock",
     "jinja2",


### PR DESCRIPTION
Was deadlocking possibly due to recursive db transactions, multiprocessing bugs or syntax errors.

Shorten transactions so that we do no filesystem access during the transaction.