### PR TITLE
remove channel name from cache object

### DIFF
--- a/conda_index/index/__init__.py
+++ b/conda_index/index/__init__.py
@@ -341,7 +341,7 @@ def _get_resolve_object(subdir, file_path=None, precs=None, repodata=None):
 
     channel = Channel("https://conda.anaconda.org/dummy-channel/%s" % subdir)
     sd = SubdirData(channel)
-    sd._process_raw_repodata_str(json.dumps(repodata))
+        sd._process_raw_repodata_str(json.dumps(repodata))
     sd._loaded = True
     SubdirData._cache_[channel.url(with_credentials=True)] = sd
 
@@ -711,7 +711,7 @@ class ChannelIndex:
 
     def cache_for_subdir(self, subdir):
         cache: sqlitecache.CondaIndexCache = self.cache_class(
-            channel_root=self.channel_root, channel=self.channel_name, subdir=subdir
+            channel_root=self.channel_root, subdir=subdir
         )
         if cache.cache_is_brand_new:
             # guaranteed to be only thread doing this?
@@ -845,9 +845,7 @@ class ChannelIndex:
 
     def _update_channeldata(self, channel_data, repodata, subdir):
 
-        cache = self.cache_class(
-            channel_root=self.channel_root, channel=self.channel_name, subdir=subdir
-        )
+        cache = self.cache_for_subdir(subdir)
 
         legacy_packages = repodata["packages"]
         conda_packages = repodata["packages.conda"]

--- a/conda_index/index/__init__.py
+++ b/conda_index/index/__init__.py
@@ -316,18 +316,9 @@ def _make_channeldata_index_html(channel_name, channeldata):
     return rendered_html
 
 
-def _get_resolve_object(subdir, file_path=None, precs=None, repodata=None):
+def _get_resolve_object(subdir, precs=None, repodata=None):
     packages = {}
     conda_packages = {}
-    if file_path:
-        with open(file_path) as fi:
-            packages = json.load(fi)
-            recs = json.load(fi)
-            for k, v in recs.items():
-                if k.endswith(CONDA_PACKAGE_EXTENSION_V1):
-                    packages[k] = v
-                elif k.endswith(CONDA_PACKAGE_EXTENSION_V2):
-                    conda_packages[k] = v
     if not repodata:
         repodata = {
             "info": {
@@ -343,7 +334,7 @@ def _get_resolve_object(subdir, file_path=None, precs=None, repodata=None):
     sd = SubdirData(channel)
     try:
         # the next version of conda >= 4.13.0
-        # repodata = copy.deepcopy(repodata) # slower thahn json.dumps/load loop
+        # repodata = copy.deepcopy(repodata) # slower than json.dumps/load loop
         repodata_copy = repodata.copy()
         for group in ("packages", "packages.conda"):
             repodata_copy[group] = {

--- a/conda_index/index/__init__.py
+++ b/conda_index/index/__init__.py
@@ -341,6 +341,17 @@ def _get_resolve_object(subdir, file_path=None, precs=None, repodata=None):
 
     channel = Channel("https://conda.anaconda.org/dummy-channel/%s" % subdir)
     sd = SubdirData(channel)
+    try:
+        # the next version of conda >= 4.13.0
+        # repodata = copy.deepcopy(repodata) # slower thahn json.dumps/load loop
+        repodata_copy = repodata.copy()
+        for group in ("packages", "packages.conda"):
+            repodata_copy[group] = {
+                key: value.copy() for key, value in repodata.get(group, {}).items()
+            }
+        # adds url, Channel objects to each repodata package
+        sd._process_raw_repodata(repodata_copy)  # type: ignore
+    except AttributeError:
         sd._process_raw_repodata_str(json.dumps(repodata))
     sd._loaded = True
     SubdirData._cache_[channel.url(with_credentials=True)] = sd

--- a/conda_index/index/sqlitecache.py
+++ b/conda_index/index/sqlitecache.py
@@ -82,14 +82,12 @@ class cacher:
 class CondaIndexCache:
     upstream_stage = "fs"
 
-    def __init__(self, channel_root, channel, subdir):
+    def __init__(self, channel_root, subdir):
         """
         channel_root: directory containing platform subdir's, e.g. /clones/conda-forge
-        channel: name of channel, e.g. 'main', 'conda-forge'
         subdir: platform subdir, e.g. 'linux-64'
         """
         self.channel_root = channel_root
-        self.channel = channel
         self.subdir = subdir
 
         self.subdir_path = os.path.join(channel_root, subdir)
@@ -101,7 +99,7 @@ class CondaIndexCache:
             os.mkdir(self.cache_dir)
 
         log.debug(
-            f"CondaIndexCache {channel=}, {subdir=} {self.db_filename=} {self.cache_is_brand_new=}"
+            f"CondaIndexCache {channel_root=}, {subdir=} {self.db_filename=} {self.cache_is_brand_new=}"
         )
 
     def __getstate__(self):

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -527,7 +527,7 @@ def test_file_index_noarch_osx64_1(testing_workdir):
 
     conda_index.index.update_index(testing_workdir, channel_name="test-channel")
 
-    updated_packages = expected_repodata_json.get("packages")
+    updated_packages = expected_repodata_json.get("packages", {})
     updated_packages["flask-0.11.1-py_0.tar.bz2"] = {
         "build": "py_0",
         "build_number": 0,
@@ -1020,7 +1020,7 @@ def test_new_pkg_format_preferred(testing_workdir, mocker):
         )
     # mock the extract function, so that we can assert that it is not called
     #     with the .tar.bz2, because the .conda should be preferred
-    import conda_index.index.package_streaming
+    import conda_index.index, conda_index.index.package_streaming
 
     cph_extract = mocker.spy(conda_index.index.package_streaming, "stream_conda_info")
     conda_index.index.update_index(
@@ -1263,7 +1263,7 @@ def test_index_clears_changed_packages(testing_workdir):
     conda_index.index.update_index(testing_workdir, channel_name="test-channel")
 
     index_cache = conda_index.index.sqlitecache.CondaIndexCache(
-        channel_root=testing_workdir, channel="test-channel", subdir="osx-64"
+        channel_root=testing_workdir, subdir="osx-64"
     )
     assert list(index_cache.changed_packages()) == []
 
@@ -1284,8 +1284,8 @@ def test_index_clears_changed_packages(testing_workdir):
 
     conda_index.index.update_index(testing_workdir, channel_name="test-channel")
 
-    # indepentent database connection
+    # force new database connection
     index_cache = conda_index.index.sqlitecache.CondaIndexCache(
-        channel_root=testing_workdir, channel="test-channel", subdir="osx-64"
+        channel_root=testing_workdir, subdir="osx-64"
     )
     assert list(index_cache.changed_packages()) == []

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1020,7 +1020,8 @@ def test_new_pkg_format_preferred(testing_workdir, mocker):
         )
     # mock the extract function, so that we can assert that it is not called
     #     with the .tar.bz2, because the .conda should be preferred
-    import conda_index.index, conda_index.index.package_streaming
+    import conda_index.index
+    import conda_index.index.package_streaming
 
     cph_extract = mocker.spy(conda_index.index.package_streaming, "stream_conda_info")
     conda_index.index.update_index(


### PR DESCRIPTION
Not really used. Previously we had to take care to avoid bugs with inconsistent channel names, now we avoid relying on it entirely.