### PR TITLE
Use filecmp instead of comparing two hashes (#35)

### DIFF
--- a/conda_index/utils.py
+++ b/conda_index/utils.py
@@ -1,4 +1,5 @@
 import hashlib
+import filecmp
 import os
 from concurrent.futures.thread import ThreadPoolExecutor
 from contextlib import contextmanager
@@ -69,14 +70,5 @@ def file_contents_match(pathA, pathB):
     """
     Return True if pathA and pathB have identical contents.
     """
-    if os.stat(pathA).st_size != os.stat(pathB).st_size:
-        return False
 
-    hashes = []
-    for path in (pathA, pathB):
-        hashfunc = hashlib.blake2b()
-        with open(path, "rb") as data:
-            while block := data.read(1 << 18):
-                hashfunc.update(block)
-        hashes.append(hashfunc.digest())
-    return hashes[0] == hashes[1]
+    return filecmp.cmp(pathA, pathB)


### PR DESCRIPTION
Use filecmp.cmp() to compare files instead of generating and testing file hashes.

filecmp.cmp() with shallow=True (default) tests os.stat() signatures, so no explicit check is needed anymore.