### PR TITLE
avoid multprocessing fork, even on Linux

### DIFF
--- a/conda_index/index/__init__.py
+++ b/conda_index/index/__init__.py
@@ -7,6 +7,7 @@ import copy
 import functools
 import json
 import logging
+import multiprocessing
 import os
 import sys
 import time
@@ -474,8 +475,8 @@ def thread_executor_factory(debug, threads):
     return (
         DummyExecutor()
         if (debug or threads == 1)
-        else ProcessPoolExecutor(threads, initializer=logging_config)
-    )
+        else ProcessPoolExecutor(threads, initializer=logging_config, mp_context=multiprocessing.get_context("spawn"))
+    ) # "fork" start method may cause hangs even on Linux?
 
 
 class ChannelIndex:


### PR DESCRIPTION
Fork seems to hang (that's why spawn is the default on osx), possibly because we have threads & fork at the same time? Better to use spawn, avoiding the problem everywhere. We don't have to pass large amounts of data across the process boundary since we split after completely populating the cache.db