### PR TITLE
replace channeldata with newest timestamp when versions match

### DIFF
--- a/conda_index/index/__init__.py
+++ b/conda_index/index/__init__.py
@@ -1129,14 +1129,14 @@ class ChannelIndex:
 
         if isinstance(content, str):
             mode = "w"
-            opts = {"encoding": "utf-8"}
+            encoding = "utf-8"
             newline = "\n"
         else:
             mode = "wb"
-            opts = {}
+            encoding = None
             newline = b"\n"
 
-        with open(output_temp_path, mode=mode, **opts) as fh:
+        with open(output_temp_path, mode=mode, encoding=encoding) as fh:
             fh.write(content)
             if write_newline_end:
                 fh.write(newline)

--- a/conda_index/index/__init__.py
+++ b/conda_index/index/__init__.py
@@ -892,31 +892,23 @@ class ChannelIndex:
         groups = []
         package_groups = groupby(lambda x: x[1]["name"], all_repodata_packages.items())
         for groupname, group in package_groups.items():
-            if groupname not in package_data or package_data[groupname].get(
-                "run_exports"
-            ):
-                # Pay special attention to groups that have run_exports - we
-                # need to process each version group by version; take newest per
-                # version group.  We handle groups that are not in the index at
-                # all yet similarly, because we can't check if they have any
-                # run_exports
-                for vgroup in groupby(lambda x: x[1]["version"], group).values():
-                    candidate = next(
-                        iter(
-                            sorted(
-                                vgroup,
-                                key=lambda x: x[1].get("timestamp", 0),
-                                reverse=True,
-                            )
-                        )
-                    )
-                    _append_group(groups, candidate)
-            else:
-                # take newest per group
+            # Pay special attention to groups that have run_exports - we
+            # need to process each version group by version; take newest per
+            # version group.  We handle groups that are not in the index at
+            # all yet similarly, because we can't check if they have any
+            # run_exports.
+
+            # This is more deterministic than, but slower than the old "newest
+            # timestamp across all versions if no run_exports". When
+            # channeldata.json is not being built from scratch the speed
+            # difference is not noticable.
+            for vgroup in groupby(lambda x: x[1]["version"], group).values():
                 candidate = next(
                     iter(
                         sorted(
-                            group, key=lambda x: x[1].get("timestamp", 0), reverse=True
+                            vgroup,
+                            key=lambda x: x[1].get("timestamp", 0),
+                            reverse=True,
                         )
                     )
                 )

--- a/conda_index/index/__init__.py
+++ b/conda_index/index/__init__.py
@@ -899,9 +899,9 @@ class ChannelIndex:
             # run_exports.
 
             # This is more deterministic than, but slower than the old "newest
-            # timestamp across all versions if no run_exports". When
-            # channeldata.json is not being built from scratch the speed
-            # difference is not noticable.
+            # timestamp across all versions if no run_exports", unsatisfying
+            # when old versions get new builds. When channeldata.json is not
+            # being built from scratch the speed difference is not noticable.
             for vgroup in groupby(lambda x: x[1]["version"], group).values():
                 candidate = next(
                     iter(

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -17,7 +17,6 @@ PATCH_GENERATOR = os.path.join(os.path.dirname(__file__), "gen_patch.py")
 
 def test_coverage_1():
     conda_index.index.logging_config()
-    conda_index.index.ensure_binary(b"")
 
 
 def test_dummy_executor():

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -524,7 +524,7 @@ def test_file_index_noarch_osx64_1(testing_workdir):
 
     # only tell index to index one of them and then assert that it was added
     p = os.path.join(testing_workdir, "index_file")
-    with open(os.path.join(testing_workdir, "index_file"), "a+") as fh:
+    with open(p, "a+") as fh:
         fh.write("noarch/flask-0.11.1-py_0.tar.bz2\n")
         fh.write("osx/fly-2.5.2-0.tar.bz2\n")
 


### PR DESCRIPTION
Fixes #43 

We "pay special attention" to every package now, so that we don't get older-version-newer-timestamp in a channeldata.json-from-scratch, compared to a channeldata.json-not-from-scratch. Appears to be about the same speed as long as we are re-using older channeldata.json; slower the one time we have to make channeldata.json from scratch.